### PR TITLE
modified openBankAccount method to catch illegal arguments

### DIFF
--- a/src/bankapp/Menu.java
+++ b/src/bankapp/Menu.java
@@ -43,13 +43,32 @@ public class Menu {
 	}
 
 	//Gabriela
-	public void createBankAccount(String accountName) {
+	/*public void createBankAccount(String accountName) {
 		BankAccount account = currentCustomer.openAccount(accountName);
 		currentAccount = account;
 		bankAccountList = currentCustomer.getAccountList();
 		System.out.println("Account " + accountName +" succesfully created.");
 		System.out.println();
 
+	}*/
+	
+	public void createBankAccount() {
+		boolean success = false;
+	    while (!success) {
+	        System.out.println("Enter a name for your new bank account:");
+	        System.out.println("This name must not be the same name as an existing bank account under your user account and can only include alphabetical letters and numbers.");
+	        keyboardInput.next();
+	        String bankAccountNameInput = getUserStringInput();
+	        try {
+	        	
+	            currentCustomer.openAccount(bankAccountNameInput);
+	            System.out.println("Bank account " + bankAccountNameInput + " created succesfully.");
+	            success = true;
+	        } catch (IllegalArgumentException e) {
+	            System.out.println("Account opening failed. An invalid bank account name was entered.");
+	            System.out.println();
+	        }
+	    }
 	}
 
 
@@ -89,10 +108,7 @@ public class Menu {
 	//Claire
 	public void processMenuSelection(int userSelection) {
 		if(userSelection == 1) { //Create account
-			System.out.println("Enter bank account name:");
-			keyboardInput.nextLine();
-			String accountName = getUserStringInput();
-			createBankAccount(accountName);
+			createBankAccount();
 		}
 		else if(userSelection == 2) { //View account list
 			displayAccountList();

--- a/src/tests/BankCustomerTests.java
+++ b/src/tests/BankCustomerTests.java
@@ -74,4 +74,29 @@ public class BankCustomerTests {
 		});
 		
 	}
+	
+	@Test
+	public void testNoRepeatBankAccountName() {
+		BankCustomer testUser = new BankCustomer("testUser");
+		BankAccount testBankAccount1 = testUser.openAccount("testing1");
+
+		assertThrows(IllegalArgumentException.class, () -> {
+			testUser.openAccount("testing1");
+		});
+		
+	}
+	
+	@Test
+	public void testAllowsNonRepeatBankAccountName() {
+		BankCustomer testUser = new BankCustomer("testUser");
+		BankAccount testBankAccount1 = testUser.openAccount("testing1");
+		BankAccount testBankAccount2 = testUser.openAccount("differentName");
+		
+		assertEquals(testUser.getAccountList().size(), 2);
+		
+	}
+	
+	
+	
+	
 }

--- a/src/tests/MenuTests.java
+++ b/src/tests/MenuTests.java
@@ -11,15 +11,7 @@ import java.io.InputStream;
 
 public class MenuTests {
 	
-	@Test
-	public void testCustomerBankAccountCreation() {
-		
-		Menu testMenu = new Menu();
-		testMenu.createCustomerUser("testUser");
-		testMenu.createBankAccount("name");
-		assertEquals(1, testMenu.getBankAccountList().size());
-		
-	}
+	
 	@Test
 	public void testInvalidMenuSelection() {
 		Menu testMenu = new Menu();


### PR DESCRIPTION
Added tests to BankCustomer class to ensure an illegal argument is thrown when a repeat bank account name is entered.

Modified openBankAccount method in Menu to have a loop to catch illegal arguments if invalid bank account names are entered and then redirect users to enter a new name.